### PR TITLE
`ContainsText` and `DoesNotContainText` matchers to accept varargs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ targetCompatibility = 1.8
 defaultTasks 'test', 'install'
 
 dependencies {
-  implementation group: 'org.apache.pdfbox', name: 'pdfbox', version: '2.0.22', transitive: true
+  implementation group: 'org.apache.pdfbox', name: 'pdfbox', version: '2.0.24', transitive: true
   implementation group: 'org.hamcrest', name: 'hamcrest-core', version: '1.3', transitive: false
   testImplementation group: 'junit', name: 'junit', version: '4.13.2', transitive: false
   testImplementation group: 'org.hamcrest', name: 'hamcrest-all', version: '1.3', transitive: false

--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ dependencies {
   implementation group: 'org.hamcrest', name: 'hamcrest-core', version: '1.3', transitive: false
   testImplementation group: 'junit', name: 'junit', version: '4.13.2', transitive: false
   testImplementation group: 'org.hamcrest', name: 'hamcrest-all', version: '1.3', transitive: false
-  implementation group: 'org.assertj', name: 'assertj-core', version: '3.19.0', transitive: false
+  implementation group: 'org.assertj', name: 'assertj-core', version: '3.21.0', transitive: false
 }
 
 repositories{

--- a/src/main/java/com/codeborne/pdftest/PDF.java
+++ b/src/main/java/com/codeborne/pdftest/PDF.java
@@ -127,7 +127,7 @@ public class PDF {
     return result.toByteArray();
   }
 
-  public static Matcher<PDF> containsText(String text) {
+  public static Matcher<PDF> containsText(String... text) {
     return new ContainsText(text);
   }
   public static Matcher<PDF> doesNotContainText(String text) {

--- a/src/main/java/com/codeborne/pdftest/PDF.java
+++ b/src/main/java/com/codeborne/pdftest/PDF.java
@@ -130,8 +130,8 @@ public class PDF {
   public static Matcher<PDF> containsText(String text, String... texts) {
     return new ContainsText(text, texts);
   }
-  public static Matcher<PDF> doesNotContainText(String... texts) {
-    return new DoesNotContainText(texts);
+  public static Matcher<PDF> doesNotContainText(String text, String... texts) {
+    return new DoesNotContainText(text, texts);
   }
   public static Matcher<PDF> containsExactText(String text) {
     return new ContainsExactText(text);

--- a/src/main/java/com/codeborne/pdftest/PDF.java
+++ b/src/main/java/com/codeborne/pdftest/PDF.java
@@ -127,8 +127,8 @@ public class PDF {
     return result.toByteArray();
   }
 
-  public static Matcher<PDF> containsText(String... texts) {
-    return new ContainsText(texts);
+  public static Matcher<PDF> containsText(String text, String... texts) {
+    return new ContainsText(text, texts);
   }
   public static Matcher<PDF> doesNotContainText(String... texts) {
     return new DoesNotContainText(texts);

--- a/src/main/java/com/codeborne/pdftest/PDF.java
+++ b/src/main/java/com/codeborne/pdftest/PDF.java
@@ -127,11 +127,11 @@ public class PDF {
     return result.toByteArray();
   }
 
-  public static Matcher<PDF> containsText(String... text) {
-    return new ContainsText(text);
+  public static Matcher<PDF> containsText(String... texts) {
+    return new ContainsText(texts);
   }
-  public static Matcher<PDF> doesNotContainText(String text) {
-    return new DoesNotContainText(text);
+  public static Matcher<PDF> doesNotContainText(String... texts) {
+    return new DoesNotContainText(texts);
   }
   public static Matcher<PDF> containsExactText(String text) {
     return new ContainsExactText(text);

--- a/src/main/java/com/codeborne/pdftest/assertj/PdfAssert.java
+++ b/src/main/java/com/codeborne/pdftest/assertj/PdfAssert.java
@@ -15,9 +15,9 @@ public class PdfAssert extends AbstractAssert<PdfAssert, PDF> {
     super(actual, PdfAssert.class);
   }
 
-  public PdfAssert containsText(String substring) {
+  public PdfAssert containsText(String... strings) {
     isNotNull();
-    assertThat(actual, new ContainsText(substring));
+    assertThat(actual, new ContainsText(strings));
     return this;
   }
 

--- a/src/main/java/com/codeborne/pdftest/assertj/PdfAssert.java
+++ b/src/main/java/com/codeborne/pdftest/assertj/PdfAssert.java
@@ -21,9 +21,9 @@ public class PdfAssert extends AbstractAssert<PdfAssert, PDF> {
     return this;
   }
 
-  public PdfAssert doesNotContainText(String... strings) {
+  public PdfAssert doesNotContainText(String text, String... texts) {
     isNotNull();
-    assertThat(actual, new DoesNotContainText(strings));
+    assertThat(actual, new DoesNotContainText(text, texts));
     return this;
   }
 

--- a/src/main/java/com/codeborne/pdftest/assertj/PdfAssert.java
+++ b/src/main/java/com/codeborne/pdftest/assertj/PdfAssert.java
@@ -21,9 +21,9 @@ public class PdfAssert extends AbstractAssert<PdfAssert, PDF> {
     return this;
   }
 
-  public PdfAssert doesNotContainText(String substring) {
+  public PdfAssert doesNotContainText(String... strings) {
     isNotNull();
-    assertThat(actual, new DoesNotContainText(substring));
+    assertThat(actual, new DoesNotContainText(strings));
     return this;
   }
 

--- a/src/main/java/com/codeborne/pdftest/assertj/PdfAssert.java
+++ b/src/main/java/com/codeborne/pdftest/assertj/PdfAssert.java
@@ -15,9 +15,9 @@ public class PdfAssert extends AbstractAssert<PdfAssert, PDF> {
     super(actual, PdfAssert.class);
   }
 
-  public PdfAssert containsText(String... strings) {
+  public PdfAssert containsText(String text, String... texts) {
     isNotNull();
-    assertThat(actual, new ContainsText(strings));
+    assertThat(actual, new ContainsText(text, texts));
     return this;
   }
 

--- a/src/main/java/com/codeborne/pdftest/matchers/ContainsText.java
+++ b/src/main/java/com/codeborne/pdftest/matchers/ContainsText.java
@@ -4,8 +4,6 @@ import com.codeborne.pdftest.PDF;
 import org.hamcrest.Description;
 
 import java.util.Arrays;
-import java.util.List;
-import java.util.stream.Collectors;
 
 public class ContainsText extends PDFMatcher {
   private final String text;
@@ -31,12 +29,9 @@ public class ContainsText extends PDFMatcher {
   @Override
   public void describeTo(Description description) {
     description.appendText("a PDF containing ");
-    if (texts.length > 0) {
-      List<String> reducedStrings = Arrays.stream(texts).map(this::reduceSpaces).collect(Collectors.toList());
-      reducedStrings.add(0, reduceSpaces(text));
-      description.appendValueList("", ", ", "", reducedStrings);
-    } else {
-      description.appendValue(reduceSpaces(text));
-    }
+    buildErrorMessage(description, text, texts);
   }
+
+
 }
+

--- a/src/main/java/com/codeborne/pdftest/matchers/ContainsText.java
+++ b/src/main/java/com/codeborne/pdftest/matchers/ContainsText.java
@@ -3,16 +3,21 @@ package com.codeborne.pdftest.matchers;
 import com.codeborne.pdftest.PDF;
 import org.hamcrest.Description;
 
-public class ContainsText extends PDFMatcher {
-  private final String substring;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 
-  public ContainsText(String substring) {
-    this.substring = substring;
+public class ContainsText extends PDFMatcher {
+  private final String[] strings;
+
+  public ContainsText(String... strings) {
+    this.strings = strings;
   }
 
   @Override
   protected boolean matchesSafely(PDF item) {
-    return reduceSpaces(item.text).contains(reduceSpaces(substring));
+    String reducedPdfText = reduceSpaces(item.text);
+    return Arrays.stream(strings).allMatch(str -> reducedPdfText.contains(reduceSpaces(str)));
   }
 
   @Override
@@ -22,6 +27,7 @@ public class ContainsText extends PDFMatcher {
 
   @Override
   public void describeTo(Description description) {
-    description.appendText("a PDF containing ").appendValue(reduceSpaces(substring));
+    List<String> reducedStrings = Arrays.stream(strings).map(this::reduceSpaces).collect(Collectors.toList());
+    description.appendText("a PDF containing ").appendValue(reducedStrings);
   }
 }

--- a/src/main/java/com/codeborne/pdftest/matchers/ContainsText.java
+++ b/src/main/java/com/codeborne/pdftest/matchers/ContainsText.java
@@ -8,16 +8,19 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 public class ContainsText extends PDFMatcher {
-  private final String[] strings;
+  private final String text;
+  private final String[] texts;
 
-  public ContainsText(String... strings) {
-    this.strings = strings;
+  public ContainsText(String text, String... texts) {
+    this.text = text;
+    this.texts = texts;
   }
 
   @Override
   protected boolean matchesSafely(PDF item) {
     String reducedPdfText = reduceSpaces(item.text);
-    return Arrays.stream(strings).allMatch(str -> reducedPdfText.contains(reduceSpaces(str)));
+    return reducedPdfText.contains(reduceSpaces(text)) &&
+            Arrays.stream(texts).allMatch(str -> reducedPdfText.contains(reduceSpaces(str)));
   }
 
   @Override
@@ -27,7 +30,13 @@ public class ContainsText extends PDFMatcher {
 
   @Override
   public void describeTo(Description description) {
-    List<String> reducedStrings = Arrays.stream(strings).map(this::reduceSpaces).collect(Collectors.toList());
-    description.appendText("a PDF containing ").appendValue(reducedStrings);
+    description.appendText("a PDF containing ");
+    if (texts.length > 0) {
+      List<String> reducedStrings = Arrays.stream(texts).map(this::reduceSpaces).collect(Collectors.toList());
+      reducedStrings.add(0, reduceSpaces(text));
+      description.appendValueList("", ", ", "", reducedStrings);
+    } else {
+      description.appendValue(reduceSpaces(text));
+    }
   }
 }

--- a/src/main/java/com/codeborne/pdftest/matchers/DoesNotContainText.java
+++ b/src/main/java/com/codeborne/pdftest/matchers/DoesNotContainText.java
@@ -8,16 +8,19 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 public class DoesNotContainText extends PDFMatcher {
-  private final String[] strings;
+  private final String text;
+  private final String[] texts;
 
-  public DoesNotContainText(String... strings) {
-    this.strings = strings;
+  public DoesNotContainText(String text, String... texts) {
+    this.text = text;
+    this.texts = texts;
   }
 
   @Override
   protected boolean matchesSafely(PDF item) {
-    String pdfReducedText = reduceSpaces(item.text);
-    return Arrays.stream(strings).noneMatch(str -> pdfReducedText.contains(reduceSpaces(str)));
+    String reducedPdfText = reduceSpaces(item.text);
+    return !reducedPdfText.contains(reduceSpaces(text)) &&
+            Arrays.stream(texts).noneMatch(str -> reducedPdfText.contains(reduceSpaces(str)));
   }
 
   @Override
@@ -27,7 +30,13 @@ public class DoesNotContainText extends PDFMatcher {
 
   @Override
   public void describeTo(Description description) {
-    List<String> reducedStrings = Arrays.stream(strings).map(this::reduceSpaces).collect(Collectors.toList());
-    description.appendText("a PDF not containing ").appendValue(reducedStrings);
+    description.appendText("a PDF not containing ");
+    if (texts.length > 0) {
+      List<String> reducedStrings = Arrays.stream(texts).map(this::reduceSpaces).collect(Collectors.toList());
+      reducedStrings.add(0, reduceSpaces(text));
+      description.appendValueList("", ", ", "", reducedStrings);
+    } else {
+      description.appendValue(reduceSpaces(text));
+    }
   }
 }

--- a/src/main/java/com/codeborne/pdftest/matchers/DoesNotContainText.java
+++ b/src/main/java/com/codeborne/pdftest/matchers/DoesNotContainText.java
@@ -31,12 +31,6 @@ public class DoesNotContainText extends PDFMatcher {
   @Override
   public void describeTo(Description description) {
     description.appendText("a PDF not containing ");
-    if (texts.length > 0) {
-      List<String> reducedStrings = Arrays.stream(texts).map(this::reduceSpaces).collect(Collectors.toList());
-      reducedStrings.add(0, reduceSpaces(text));
-      description.appendValueList("", ", ", "", reducedStrings);
-    } else {
-      description.appendValue(reduceSpaces(text));
-    }
+    buildErrorMessage(description, text, texts);
   }
 }

--- a/src/main/java/com/codeborne/pdftest/matchers/DoesNotContainText.java
+++ b/src/main/java/com/codeborne/pdftest/matchers/DoesNotContainText.java
@@ -3,16 +3,21 @@ package com.codeborne.pdftest.matchers;
 import com.codeborne.pdftest.PDF;
 import org.hamcrest.Description;
 
-public class DoesNotContainText extends PDFMatcher {
-  private final String substring;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 
-  public DoesNotContainText(String substring) {
-    this.substring = substring;
+public class DoesNotContainText extends PDFMatcher {
+  private final String[] strings;
+
+  public DoesNotContainText(String... strings) {
+    this.strings = strings;
   }
 
   @Override
   protected boolean matchesSafely(PDF item) {
-    return !reduceSpaces(item.text).contains(reduceSpaces(substring));
+    String pdfReducedText = reduceSpaces(item.text);
+    return Arrays.stream(strings).noneMatch(str -> pdfReducedText.contains(reduceSpaces(str)));
   }
 
   @Override
@@ -22,6 +27,7 @@ public class DoesNotContainText extends PDFMatcher {
 
   @Override
   public void describeTo(Description description) {
-    description.appendText("a PDF not containing ").appendValue(reduceSpaces(substring));
+    List<String> reducedStrings = Arrays.stream(strings).map(this::reduceSpaces).collect(Collectors.toList());
+    description.appendText("a PDF not containing ").appendValue(reducedStrings);
   }
 }

--- a/src/main/java/com/codeborne/pdftest/matchers/PDFMatcher.java
+++ b/src/main/java/com/codeborne/pdftest/matchers/PDFMatcher.java
@@ -1,11 +1,26 @@
 package com.codeborne.pdftest.matchers;
 
 import com.codeborne.pdftest.PDF;
+import org.hamcrest.Description;
 import org.hamcrest.SelfDescribing;
 import org.hamcrest.TypeSafeMatcher;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 
 abstract class PDFMatcher extends TypeSafeMatcher<PDF> implements SelfDescribing {
   protected String reduceSpaces(String text) {
     return text.replaceAll("[\\s\\n\\r\u00a0]+", " ").trim();
+  }
+
+  protected void buildErrorMessage(Description description, String text, String[] texts) {
+    if (texts.length > 0) {
+      List<String> reducedStrings = Arrays.stream(texts).map(this::reduceSpaces).collect(Collectors.toList());
+      reducedStrings.add(0, reduceSpaces(text));
+      description.appendValueList("", ", ", "", reducedStrings);
+    } else {
+      description.appendValue(reduceSpaces(text));
+    }
   }
 }

--- a/src/test/java/com/codeborne/pdftest/assertj/ContainsTextTest.java
+++ b/src/test/java/com/codeborne/pdftest/assertj/ContainsTextTest.java
@@ -66,4 +66,16 @@ public class ContainsTextTest {
       assertThat(fiftyIdeasPdf).containsText("50", "Quick", "Applications");
     }).isInstanceOf(AssertionError.class);
   }
+
+  @Test
+  public void shouldNotContainMultipleTexts() {
+    assertThat(fiftyIdeasPdf).doesNotContainText("42", "Slow", "Applications");
+  }
+
+  @Test
+  public void shouldFailWhenNotAllTextsAreMissing() {
+    assertThatThrownBy(() -> {
+      assertThat(fiftyIdeasPdf).doesNotContainText("42", "Slow", "Ideas");
+    }).isInstanceOf(AssertionError.class);
+  }
 }

--- a/src/test/java/com/codeborne/pdftest/assertj/ContainsTextTest.java
+++ b/src/test/java/com/codeborne/pdftest/assertj/ContainsTextTest.java
@@ -13,12 +13,14 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 public class ContainsTextTest {
 
   private PDF fiftyIdeasPdf;
+  private PDF minimalPdf;
 
   @Before
   public void setUp() throws Exception {
     fiftyIdeasPdf = new PDF(
             Objects.requireNonNull(getClass().getClassLoader().getResource("50quickideas.pdf"))
     );
+    minimalPdf = new PDF(Objects.requireNonNull(getClass().getClassLoader().getResource("minimal.pdf")));
   }
 
   @Test
@@ -46,13 +48,21 @@ public class ContainsTextTest {
   }
 
   @Test
-  public void errorDescription() throws IOException {
-    PDF pdf = new PDF(getClass().getClassLoader().getResource("minimal.pdf"));
+  public void errorDescriptionForSingleParameter() {
     assertThatThrownBy(() -> {
-      assertThat(pdf).containsText("Goodbye word");
+      assertThat(minimalPdf).containsText("Goodbye word");
     })
         .isInstanceOf(AssertionError.class)
-        .hasMessage("\nExpected: a PDF containing <[Goodbye word]>\n     but: was \"Hello World\"");
+        .hasMessage("\nExpected: a PDF containing \"Goodbye word\"\n     but: was \"Hello World\"");
+  }
+
+  @Test
+  public void errorDescriptionForMultipleParameters() {
+    assertThatThrownBy(() -> {
+      assertThat(minimalPdf).containsText("Goodbye word", "Privet");
+    })
+            .isInstanceOf(AssertionError.class)
+            .hasMessage("\nExpected: a PDF containing \"Goodbye word\", \"Privet\"\n     but: was \"Hello World\"");
   }
 
   @Test

--- a/src/test/java/com/codeborne/pdftest/assertj/ContainsTextTest.java
+++ b/src/test/java/com/codeborne/pdftest/assertj/ContainsTextTest.java
@@ -1,39 +1,48 @@
 package com.codeborne.pdftest.assertj;
 
 import com.codeborne.pdftest.PDF;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.Objects;
 
 import static com.codeborne.pdftest.assertj.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class ContainsTextTest {
-  @Test
-  public void canAssertThatPdfContainsText() throws IOException {
-    PDF pdf = new PDF(getClass().getClassLoader().getResource("50quickideas.pdf"));
-    assertThat(pdf).containsText("50 Quick Ideas to Improve your User Stories");
-    assertThat(pdf).containsText("Gojko Adzic");
-    assertThat(pdf).containsText("©2013 - 2014 Gojko Adzic");
-    assertThat(pdf).containsText("#50quickideas");
-    assertThat(pdf).containsText("https://twitter.com/search?q=#50quickideas");
+
+  private PDF fiftyIdeasPdf;
+
+  @Before
+  public void setUp() throws Exception {
+    fiftyIdeasPdf = new PDF(
+            Objects.requireNonNull(getClass().getClassLoader().getResource("50quickideas.pdf"))
+    );
   }
 
   @Test
-  public void shouldBeCaseSensitive() throws IOException {
-    PDF pdf = new PDF(getClass().getClassLoader().getResource("50quickideas.pdf"));
-    assertThat(pdf).doesNotContainText("50 quick ideas");
+  public void canAssertThatPdfContainsText() {
+    assertThat(fiftyIdeasPdf).containsText("50 Quick Ideas to Improve your User Stories");
+    assertThat(fiftyIdeasPdf).containsText("Gojko Adzic");
+    assertThat(fiftyIdeasPdf).containsText("©2013 - 2014 Gojko Adzic");
+    assertThat(fiftyIdeasPdf).containsText("#50quickideas");
+    assertThat(fiftyIdeasPdf).containsText("https://twitter.com/search?q=#50quickideas");
   }
 
   @Test
-  public void shouldIgnoreWhitespaces() throws IOException {
-    PDF pdf = new PDF(getClass().getClassLoader().getResource("50quickideas.pdf"));
-    assertThat(pdf).containsText("Gojko       Adzic");
-    assertThat(pdf).containsText("\tGojko \t Adzic\t");
-    assertThat(pdf).containsText("Gojko \n Adzic\t\n");
-    assertThat(pdf).containsText("Gojko \n Adzic\n");
-    assertThat(pdf).containsText("Gojko\r\n Adzic\r\n");
-    assertThat(pdf).containsText("Gojko \u00a0 Adzic\r\n");
+  public void shouldBeCaseSensitive() {
+    assertThat(fiftyIdeasPdf).doesNotContainText("50 quick ideas");
+  }
+
+  @Test
+  public void shouldIgnoreWhitespaces() {
+    assertThat(fiftyIdeasPdf).containsText("Gojko       Adzic");
+    assertThat(fiftyIdeasPdf).containsText("\tGojko \t Adzic\t");
+    assertThat(fiftyIdeasPdf).containsText("Gojko \n Adzic\t\n");
+    assertThat(fiftyIdeasPdf).containsText("Gojko \n Adzic\n");
+    assertThat(fiftyIdeasPdf).containsText("Gojko\r\n Adzic\r\n");
+    assertThat(fiftyIdeasPdf).containsText("Gojko \u00a0 Adzic\r\n");
   }
 
   @Test
@@ -43,6 +52,18 @@ public class ContainsTextTest {
       assertThat(pdf).containsText("Goodbye word");
     })
         .isInstanceOf(AssertionError.class)
-        .hasMessage("\nExpected: a PDF containing \"Goodbye word\"\n     but: was \"Hello World\"");
+        .hasMessage("\nExpected: a PDF containing <[Goodbye word]>\n     but: was \"Hello World\"");
+  }
+
+  @Test
+  public void pdfShouldContainMultipleTexts() {
+    assertThat(fiftyIdeasPdf).containsText("50", "Quick", "Ideas");
+  }
+
+  @Test
+  public void shouldFailWhenOneTextIsMissing() {
+    assertThatThrownBy(() -> {
+      assertThat(fiftyIdeasPdf).containsText("50", "Quick", "Applications");
+    }).isInstanceOf(AssertionError.class);
   }
 }

--- a/src/test/java/com/codeborne/pdftest/assertj/ContainsTextTest.java
+++ b/src/test/java/com/codeborne/pdftest/assertj/ContainsTextTest.java
@@ -49,18 +49,14 @@ public class ContainsTextTest {
 
   @Test
   public void errorDescriptionForSingleParameter() {
-    assertThatThrownBy(() -> {
-      assertThat(minimalPdf).containsText("Goodbye word");
-    })
+    assertThatThrownBy(() -> assertThat(minimalPdf).containsText("Goodbye word"))
         .isInstanceOf(AssertionError.class)
         .hasMessage("\nExpected: a PDF containing \"Goodbye word\"\n     but: was \"Hello World\"");
   }
 
   @Test
   public void errorDescriptionForMultipleParameters() {
-    assertThatThrownBy(() -> {
-      assertThat(minimalPdf).containsText("Goodbye word", "Privet");
-    })
+    assertThatThrownBy(() -> assertThat(minimalPdf).containsText("Goodbye word", "Privet"))
             .isInstanceOf(AssertionError.class)
             .hasMessage("\nExpected: a PDF containing \"Goodbye word\", \"Privet\"\n     but: was \"Hello World\"");
   }

--- a/src/test/java/com/codeborne/pdftest/matchers/ContainsTextTest.java
+++ b/src/test/java/com/codeborne/pdftest/matchers/ContainsTextTest.java
@@ -53,4 +53,16 @@ public class ContainsTextTest {
           is("\nExpected: a PDF containing \"Goodbye word\"\n     but: was \"Hello World\""));
     }
   }
+
+  @Test
+  public void pdfShouldContainMultipleTexts() throws IOException {
+    PDF pdf = new PDF(getClass().getClassLoader().getResource("50quickideas.pdf"));
+    assertThat(pdf, containsText("50", "Quick", "Ideas"));
+  }
+
+  @Test(expected = AssertionError.class)
+  public void shouldFailWhenOneTextIsMissing() throws IOException {
+    PDF pdf = new PDF(getClass().getClassLoader().getResource("50quickideas.pdf"));
+    assertThat(pdf, containsText("50", "Quick", "Applications"));
+  }
 }

--- a/src/test/java/com/codeborne/pdftest/matchers/ContainsTextTest.java
+++ b/src/test/java/com/codeborne/pdftest/matchers/ContainsTextTest.java
@@ -1,9 +1,11 @@
 package com.codeborne.pdftest.matchers;
 
 import com.codeborne.pdftest.PDF;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.Objects;
 
 import static com.codeborne.pdftest.PDF.containsText;
 import static com.codeborne.pdftest.PDF.doesNotContainText;
@@ -13,32 +15,39 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 
 public class ContainsTextTest {
-  @Test
-  public void canAssertThatPdfContainsText() throws IOException {
-    PDF pdf = new PDF(getClass().getClassLoader().getResource("50quickideas.pdf"));
-    assertThat(pdf, containsText("50 Quick Ideas to Improve your User Stories"));
-    assertThat(pdf, containsText("Gojko Adzic"));
-    assertThat(pdf, containsText("©2013 - 2014 Gojko Adzic"));
-    assertThat(pdf, containsText("#50quickideas"));
-    assertThat(pdf, containsText("https://twitter.com/search?q=#50quickideas"));
+
+  private PDF fiftyIdeasPdf;
+
+  @Before
+  public void setUp() throws Exception {
+    fiftyIdeasPdf = new PDF(
+            Objects.requireNonNull(getClass().getClassLoader().getResource("50quickideas.pdf"))
+    );
   }
 
   @Test
-  public void shouldBeCaseSensitive() throws IOException {
-    PDF pdf = new PDF(getClass().getClassLoader().getResource("50quickideas.pdf"));
-    assertThat(pdf, not(containsText("50 quick ideas")));
-    assertThat(pdf, doesNotContainText("50 quick ideas"));
+  public void canAssertThatPdfContainsText() {
+    assertThat(fiftyIdeasPdf, containsText("50 Quick Ideas to Improve your User Stories"));
+    assertThat(fiftyIdeasPdf, containsText("Gojko Adzic"));
+    assertThat(fiftyIdeasPdf, containsText("©2013 - 2014 Gojko Adzic"));
+    assertThat(fiftyIdeasPdf, containsText("#50quickideas"));
+    assertThat(fiftyIdeasPdf, containsText("https://twitter.com/search?q=#50quickideas"));
   }
 
   @Test
-  public void shouldIgnoreWhitespaces() throws IOException {
-    PDF pdf = new PDF(getClass().getClassLoader().getResource("50quickideas.pdf"));
-    assertThat(pdf, containsText("Gojko       Adzic"));
-    assertThat(pdf, containsText("\tGojko \t Adzic\t"));
-    assertThat(pdf, containsText("Gojko \n Adzic\t\n"));
-    assertThat(pdf, containsText("Gojko \n Adzic\n"));
-    assertThat(pdf, containsText("Gojko\r\n Adzic\r\n"));
-    assertThat(pdf, containsText("Gojko \u00a0 Adzic\r\n"));
+  public void shouldBeCaseSensitive() {
+    assertThat(fiftyIdeasPdf, not(containsText("50 quick ideas")));
+    assertThat(fiftyIdeasPdf, doesNotContainText("50 quick ideas"));
+  }
+
+  @Test
+  public void shouldIgnoreWhitespaces() {
+    assertThat(fiftyIdeasPdf, containsText("Gojko       Adzic"));
+    assertThat(fiftyIdeasPdf, containsText("\tGojko \t Adzic\t"));
+    assertThat(fiftyIdeasPdf, containsText("Gojko \n Adzic\t\n"));
+    assertThat(fiftyIdeasPdf, containsText("Gojko \n Adzic\n"));
+    assertThat(fiftyIdeasPdf, containsText("Gojko\r\n Adzic\r\n"));
+    assertThat(fiftyIdeasPdf, containsText("Gojko \u00a0 Adzic\r\n"));
   }
 
   @Test
@@ -50,19 +59,17 @@ public class ContainsTextTest {
     }
     catch (AssertionError expected) {
       assertThat(expected.getMessage(),
-          is("\nExpected: a PDF containing \"Goodbye word\"\n     but: was \"Hello World\""));
+          is("\nExpected: a PDF containing <[Goodbye word]>\n     but: was \"Hello World\""));
     }
   }
 
   @Test
-  public void pdfShouldContainMultipleTexts() throws IOException {
-    PDF pdf = new PDF(getClass().getClassLoader().getResource("50quickideas.pdf"));
-    assertThat(pdf, containsText("50", "Quick", "Ideas"));
+  public void pdfShouldContainMultipleTexts() {
+    assertThat(fiftyIdeasPdf, containsText("50", "Quick", "Ideas"));
   }
 
   @Test(expected = AssertionError.class)
-  public void shouldFailWhenOneTextIsMissing() throws IOException {
-    PDF pdf = new PDF(getClass().getClassLoader().getResource("50quickideas.pdf"));
-    assertThat(pdf, containsText("50", "Quick", "Applications"));
+  public void shouldFailWhenOneTextIsMissing() {
+    assertThat(fiftyIdeasPdf, containsText("50", "Quick", "Applications"));
   }
 }

--- a/src/test/java/com/codeborne/pdftest/matchers/ContainsTextTest.java
+++ b/src/test/java/com/codeborne/pdftest/matchers/ContainsTextTest.java
@@ -1,6 +1,7 @@
 package com.codeborne.pdftest.matchers;
 
 import com.codeborne.pdftest.PDF;
+import com.codeborne.pdftest.assertj.Assertions;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -9,6 +10,7 @@ import java.util.Objects;
 
 import static com.codeborne.pdftest.PDF.containsText;
 import static com.codeborne.pdftest.PDF.doesNotContainText;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -17,12 +19,14 @@ import static org.junit.Assert.fail;
 public class ContainsTextTest {
 
   private PDF fiftyIdeasPdf;
+  private PDF minimalPdf;
 
   @Before
   public void setUp() throws Exception {
     fiftyIdeasPdf = new PDF(
             Objects.requireNonNull(getClass().getClassLoader().getResource("50quickideas.pdf"))
     );
+    minimalPdf = new PDF(Objects.requireNonNull(getClass().getClassLoader().getResource("minimal.pdf")));
   }
 
   @Test
@@ -51,16 +55,22 @@ public class ContainsTextTest {
   }
 
   @Test
-  public void errorDescription() throws IOException {
-    PDF pdf = new PDF(getClass().getClassLoader().getResource("minimal.pdf"));
+  public void errorDescriptionForSingleParameter() {
     try {
-      assertThat(pdf, containsText("Goodbye word"));
+      assertThat(minimalPdf, containsText("Goodbye word"));
       fail("expected AssertionError");
     }
     catch (AssertionError expected) {
       assertThat(expected.getMessage(),
-          is("\nExpected: a PDF containing <[Goodbye word]>\n     but: was \"Hello World\""));
+          is("\nExpected: a PDF containing \"Goodbye word\"\n     but: was \"Hello World\""));
     }
+  }
+
+  @Test
+  public void errorDescriptionForMultipleParameters() {
+    assertThatThrownBy(() -> Assertions.assertThat(minimalPdf).containsText("Goodbye word", "Privet"))
+            .isInstanceOf(AssertionError.class)
+            .hasMessage("\nExpected: a PDF containing \"Goodbye word\", \"Privet\"\n     but: was \"Hello World\"");
   }
 
   @Test

--- a/src/test/java/com/codeborne/pdftest/matchers/DoesNotContainTextTest.java
+++ b/src/test/java/com/codeborne/pdftest/matchers/DoesNotContainTextTest.java
@@ -1,9 +1,11 @@
 package com.codeborne.pdftest.matchers;
 
 import com.codeborne.pdftest.PDF;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.Objects;
 
 import static com.codeborne.pdftest.PDF.doesNotContainText;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -11,17 +13,25 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.fail;
 
 public class DoesNotContainTextTest {
-  @Test
-  public void canAssertThatPdfContainsText() throws IOException {
-    PDF pdf = new PDF(getClass().getClassLoader().getResource("50quickideas.pdf"));
-    assertThat(pdf, doesNotContainText("42 Quick Ideas"));
-    assertThat(pdf, doesNotContainText("Bruce Willis"));
+
+  private PDF fiftyIdeasPdf;
+
+  @Before
+  public void setUp() throws Exception {
+    fiftyIdeasPdf = new PDF(
+            Objects.requireNonNull(getClass().getClassLoader().getResource("50quickideas.pdf"))
+    );
   }
 
   @Test
-  public void shouldBeCaseSensitive() throws IOException {
-    PDF pdf = new PDF(getClass().getClassLoader().getResource("50quickideas.pdf"));
-    assertThat(pdf, doesNotContainText("50 quick ideas"));
+  public void canAssertThatPdfContainsText() {
+    assertThat(fiftyIdeasPdf, doesNotContainText("42 Quick Ideas"));
+    assertThat(fiftyIdeasPdf, doesNotContainText("Bruce Willis"));
+  }
+
+  @Test
+  public void shouldBeCaseSensitive() {
+    assertThat(fiftyIdeasPdf, doesNotContainText("50 quick ideas"));
   }
 
   @Test
@@ -33,7 +43,17 @@ public class DoesNotContainTextTest {
     }
     catch (AssertionError expected) {
       assertThat(expected.getMessage(),
-          is("\nExpected: a PDF not containing \"Hello World\"\n     but: was \"Hello World\""));
+          is("\nExpected: a PDF not containing <[Hello World]>\n     but: was \"Hello World\""));
     }
+  }
+
+  @Test
+  public void shouldNotContainMultipleTexts() {
+    assertThat(fiftyIdeasPdf, doesNotContainText("42", "Slow", "Applications"));
+  }
+
+  @Test(expected = AssertionError.class)
+  public void shouldFailWhenNotAllTextsAreMissing() {
+    assertThat(fiftyIdeasPdf, doesNotContainText("42", "Slow", "Ideas"));
   }
 }

--- a/src/test/java/com/codeborne/pdftest/matchers/DoesNotContainTextTest.java
+++ b/src/test/java/com/codeborne/pdftest/matchers/DoesNotContainTextTest.java
@@ -15,12 +15,14 @@ import static org.junit.Assert.fail;
 public class DoesNotContainTextTest {
 
   private PDF fiftyIdeasPdf;
+  private PDF minimalPdf;
 
   @Before
   public void setUp() throws Exception {
     fiftyIdeasPdf = new PDF(
             Objects.requireNonNull(getClass().getClassLoader().getResource("50quickideas.pdf"))
     );
+    minimalPdf = new PDF(Objects.requireNonNull(getClass().getClassLoader().getResource("minimal.pdf")));
   }
 
   @Test
@@ -35,15 +37,26 @@ public class DoesNotContainTextTest {
   }
 
   @Test
-  public void errorDescription() throws IOException {
-    PDF pdf = new PDF(getClass().getClassLoader().getResource("minimal.pdf"));
+  public void errorDescriptionForSingleParameter() {
     try {
-      assertThat(pdf, doesNotContainText("Hello World"));
+      assertThat(minimalPdf, doesNotContainText("Hello World"));
       fail("expected AssertionError");
     }
     catch (AssertionError expected) {
       assertThat(expected.getMessage(),
-          is("\nExpected: a PDF not containing <[Hello World]>\n     but: was \"Hello World\""));
+          is("\nExpected: a PDF not containing \"Hello World\"\n     but: was \"Hello World\""));
+    }
+  }
+
+  @Test
+  public void errorDescriptionForMultipleParameters() {
+    try {
+      assertThat(minimalPdf, doesNotContainText("Hello", "World"));
+      fail("expected AssertionError");
+    }
+    catch (AssertionError expected) {
+      assertThat(expected.getMessage(),
+              is("\nExpected: a PDF not containing \"Hello\", \"World\"\n     but: was \"Hello World\""));
     }
   }
 


### PR DESCRIPTION
Updated `ContainsText` and `DoesNotContainText` matchers for both Hamcrest and AssertJ to accept varargs instead of a single string. That will make tests shorter and easier when need to assert a PDF against more than one string.