### PR TITLE
Bump update from JUnit4 to JUnit5: using new libraries with existing …

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -1,8 +1,9 @@
 dependencies {
   implementation group: 'org.apache.pdfbox', name: 'pdfbox', version: '2.0.27', transitive: true
   implementation group: 'org.hamcrest', name: 'hamcrest', version: '2.2', transitive: false
-  testImplementation group: 'junit', name: 'junit', version: '4.13.2', transitive: false
   implementation group: 'org.assertj', name: 'assertj-core', version: '3.23.1', transitive: false
+  testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.1'
+  testImplementation 'org.junit.vintage:junit-vintage-engine:5.9.1'
 }
 
 repositories {


### PR DESCRIPTION
Hello guys! I've updated JUnit, and now we can using new libraries with existing tests.